### PR TITLE
Print port of tunnel load balancer

### DIFF
--- a/main.go
+++ b/main.go
@@ -205,7 +205,12 @@ func parse_load_balancers(args []string, tunnel bool) {
 			}
 		}
 
-		log.Printf("[INFO] Load balancer %d: %s, contention ratio: %d\n", idx+1, lb_ip_or_fqdn, cont_ratio)
+		slbport := ""
+		if tunnel {
+			slbport = ":" + strconv.Itoa(lb_port)
+		}
+
+		log.Printf("[INFO] Load balancer %d: %s%s, contention ratio: %d\n", idx+1, lb_ip_or_fqdn, slbport, cont_ratio)
 		lb_list[idx] = load_balancer{address: fmt.Sprintf("%s:%d", lb_ip_or_fqdn, lb_port), iface: iface, contention_ratio: cont_ratio, current_connections: 0}
 	}
 }


### PR DESCRIPTION
When initializing the port of the upstream load balancer is missing in tunnel mode. This is annoying if you use multiple proxies with the same address (for example, when running them in the loopback).